### PR TITLE
Refine Next.js baseline and clean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,46 @@
-# Audio to Illustrations (Barebones)
+# Podcast Image Generator
 
-A tiny FastAPI app that lets you upload an audio file, plays it in the browser, and uses GPT to:
-1) transcribe
-2) detect topic shifts with timestamps
-3) generate image prompts
-4) create images for those prompts
+A baseline project that combines a Next.js frontend with an Express API. The API exposes endpoints for audio uploads and GPT-powered responses, while the frontend is a minimal Next.js scaffold.
 
-It then shows the images at the right time as the audio plays.
+## Prerequisites
+- Node.js 18+
+- An OpenAI API key available as `OPENAI_API_KEY` for the `/gpt` endpoint
 
-## What this is
-- A minimal scaffold so you can take it further.
-- Works locally.
-- Uses the OpenAI Python SDK for Whisper transcription, GPT topic segmentation, and image generation.
-- Stores outputs to `app/storage/<job_id>/...`
+## Local Development
+Install dependencies for both the frontend and API:
 
-## What you need
-- Python 3.10+
-- An OpenAI API key
-
-## Quick start
 ```bash
-# 1) Create and activate venv
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-
-# 2) Install deps
-pip install -r requirements.txt
-
-# 3) Add your API key
-cp .env.example .env
-# edit .env and set OPENAI_API_KEY
-
-# 4) Run
-uvicorn app.main:app --reload
+npm install
+npm --prefix api install
 ```
 
-Then open http://localhost:8000.
+Start the development servers:
 
-## How it works
-1. Upload an audio file on the home page.
-2. The server saves it to `app/storage/<job_id>/audio.<ext>`
-3. `pipeline.process_audio()` does:
-   - Transcribe with Whisper.
-   - Ask a GPT model to propose timecoded "key moments" as JSON with a short title and an image prompt per moment.
-   - Generate an image per prompt with the Images API.
-4. The browser polls `/segments/<job_id>` for the JSON list.
-5. As the audio plays, client code checks the current time against the segments and swaps in the relevant image.
-
-## Notes
-- This is intentionally barebones. Expect to improve the segmentation prompt, fallback logic, caching, and error handling.
-- For a fast first run, you can set `ENABLE_IMAGE_GEN=false` in `.env` to skip image generation and use placeholders.
-- Supported audio types depend on your local ffmpeg support for Whisper. WAV/MP3/M4A are usually fine.
-
-## Docker (optional)
 ```bash
-docker build -t audio2pics .
-docker run -it --rm -p 8000:8000 --env-file .env -v ${PWD}/app/storage:/app/app/storage audio2pics
+npm run dev            # Next.js on http://localhost:3000
+npm --prefix api dev   # Express API on http://localhost:4000
+```
+
+## Docker
+Run the full stack (web, API, and MinIO storage) using Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+Services started:
+- **web** – Next.js app on `localhost:3000`
+- **api** – Express API on `localhost:4000`
+- **minio** – S3-compatible storage on `localhost:9000` (user `minio`, password `minio123`)
+
+Stop the stack with `docker compose down`.
+
+## Testing and Linting
+```bash
+npm test              # placeholder tests for Next.js app
+npm run lint          # ESLint
+npm --prefix api test # placeholder tests for API
 ```
 
 ## License
 MIT
-# podcast-image-generator

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "echo 'No tests'"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
-      </body>
+      <body>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- remove Google font imports to allow offline Next.js builds
- document Next.js + Express setup and Docker workflow
- add placeholder test script and remove stray file

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm --prefix api test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c826a2cc8325ad7251c80897d664