### PR TITLE
feat(api): add audio upload endpoint with job ID storage

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,17 +1,58 @@
 import express from 'express';
 import multer from 'multer';
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
 import { OpenAI } from 'openai';
 
 const app = express();
-const upload = multer({ dest: 'uploads/' });
+
+// Configure multer storage to place files under /storage/{jobId}/audio
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    const jobId = randomUUID();
+    const uploadPath = path.join('/storage', jobId, 'audio');
+    fs.mkdirSync(uploadPath, { recursive: true });
+    req.jobId = jobId;
+    cb(null, uploadPath);
+  },
+  filename: (req, file, cb) => {
+    cb(null, file.originalname);
+  }
+});
+
+const upload = multer({
+  storage,
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype.startsWith('audio/')) {
+      cb(null, true);
+    } else {
+      cb(new Error('Invalid file type'));
+    }
+  },
+  limits: { fileSize: 25 * 1024 * 1024 } // 25MB limit
+});
 
 app.use(express.json());
 
-app.post('/upload', upload.single('audio'), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ error: 'No file uploaded' });
-  }
-  res.json({ filename: req.file.filename });
+app.post('/upload', (req, res) => {
+  upload.single('audio')(req, res, (err) => {
+    if (err) {
+      if (err.message === 'Invalid file type') {
+        return res.status(400).json({ error: err.message });
+      }
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(400).json({ error: 'File too large' });
+      }
+      return res.status(500).json({ error: 'Upload failed' });
+    }
+
+    if (!req.file) {
+      return res.status(400).json({ error: 'No file uploaded' });
+    }
+
+    res.json({ jobId: req.jobId });
+  });
 });
 
 app.post('/gpt', async (req, res) => {


### PR DESCRIPTION
## Summary
- store uploaded audio at `/storage/{jobId}/audio`
- ensure audio files and 25MB limit
- return generated `jobId` for follow-up requests

## Testing
- `npm --prefix api test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9591164832599b363b45f6439a3