### PR TITLE
Add frontend/backend services and env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,29 @@ npm --prefix api dev   # Express API on http://localhost:4000
 ```
 
 ## Docker
-Run the full stack (web, API, and MinIO storage) using Docker Compose:
+Run the full stack (frontend, backend, and MinIO storage) using Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
 Services started:
-- **web** – Next.js app on `localhost:3000`
-- **api** – Express API on `localhost:4000`
+- **frontend** – Next.js app on `localhost:3000`
+- **backend** – Express API on `localhost:4000` with a `/storage` volume for uploads and job data
 - **minio** – S3-compatible storage on `localhost:9000` (user `minio`, password `minio123`)
 
 Stop the stack with `docker compose down`.
+
+## Environment Variables
+
+The stack is configured through the following environment variables:
+
+| Variable | Description |
+| --- | --- |
+| `OPENAI_API_KEY` | API key used by the backend for OpenAI requests. |
+| `NEXT_PUBLIC_API_URL` | URL of the backend exposed to the frontend. Docker Compose sets this to `http://backend:4000`. |
+| `IMAGE_BACKEND` | Feature flag to select the image generation backend: `openai` (default) or `sd`. |
+| `SD_URL` | URL of the Stable Diffusion `txt2img` endpoint when `IMAGE_BACKEND=sd`. |
 
 ## Testing and Linting
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,20 @@
 version: '3.8'
 services:
-  web:
+  frontend:
     build: .
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://api:4000
+      - NEXT_PUBLIC_API_URL=http://backend:4000
     depends_on:
-      - api
-  api:
+      - backend
+  backend:
     build: ./api
     ports:
       - "4000:4000"
     volumes:
       - ./api/uploads:/app/uploads
+      - storage:/storage
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
   minio:
@@ -28,3 +29,4 @@ services:
       - minio-data:/data
 volumes:
   minio-data:
+  storage:


### PR DESCRIPTION
## Summary
- Rename Docker Compose services to `frontend` and `backend`
- Add persistent `/storage` volume for backend data
- Document env vars like `OPENAI_API_KEY`, `NEXT_PUBLIC_API_URL`, and image backend flags in README

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix api test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d378e9688325889ae7858057ca80