### PR TITLE
chore: change frontend docker port to 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker compose up --build
 ```
 
 Services started:
-- **frontend** – Next.js app on `localhost:3000`
+- **frontend** – Next.js app on `localhost:3001`
 - **backend** – Express API on `localhost:4000` with a `/storage` volume for uploads and job data
 - **minio** – S3-compatible storage on `localhost:9000` (user `minio`, password `minio123`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   frontend:
     build: .
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - NEXT_PUBLIC_API_URL=http://backend:4000
     depends_on:


### PR DESCRIPTION
## Summary
- use host port 3001 for the frontend service
- document new frontend port in README

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix api test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e0d2479c8325badcbbfdf3c2ea6f