### PR TITLE
feat: allow frontend to target configurable API

### DIFF
--- a/src/app/Segments.tsx
+++ b/src/app/Segments.tsx
@@ -8,12 +8,14 @@ interface Segment {
   title?: string;
 }
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
 export default function Segments({ jobId }: { jobId: string }) {
   const [segments, setSegments] = useState<Segment[]>([]);
 
   useEffect(() => {
     if (!jobId) return;
-    const es = new EventSource(`http://localhost:8000/segments/${jobId}`);
+    const es = new EventSource(`${API_URL}/segments/${jobId}`);
     es.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
@@ -36,7 +38,7 @@ export default function Segments({ jobId }: { jobId: string }) {
       {segments.map((seg) => (
         <div key={seg.id}>
           <img
-            src={`http://localhost:8000${seg.image_url}`}
+            src={`${API_URL}${seg.image_url}`}
             alt={seg.title || ''}
             width={320}
           />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import Segments from './Segments';
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
 export default function Home() {
   const [jobId, setJobId] = useState<string | null>(null);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
@@ -14,13 +16,18 @@ export default function Home() {
     if (!file) return;
     const formData = new FormData();
     formData.append('file', file);
-    const res = await fetch('http://localhost:8000/upload', {
+    const res = await fetch(`${API_URL}/upload`, {
       method: 'POST',
       body: formData,
     });
     const data = await res.json();
-    setJobId(data.job_id);
-    setAudioUrl('http://localhost:8000' + data.audio_url);
+    // Support both camelCase and snake_case responses
+    const id = data.job_id || data.jobId;
+    setJobId(id);
+    const audioPath = data.audio_url || data.audioUrl;
+    if (audioPath) {
+      setAudioUrl(`${API_URL}${audioPath}`);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_URL` for upload and segment requests
- fall back to localhost for local development

## Testing
- `npm test`
- `npm run lint`
- `npm --prefix api test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e32e8f98832586232c028e6f3b64