### PR TITLE
Fix Next.js frontend path resolution

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,7 @@ const eslintConfig = [
       ".next/**",
       "out/**",
       "build/**",
-      "next-env.d.ts",
+      "src/next-env.d.ts",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
-    "start": "next start",
+    "dev": "next dev ./src --turbopack",
+    "build": "next build ./src --turbopack",
+    "start": "next start ./src",
     "lint": "eslint",
     "test": "echo 'No tests'"
   },

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -19,7 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- point Next.js scripts to the `src` directory so routes resolve correctly
- move TypeScript config into `src` and update ESLint ignore path
- remove empty `favicon.ico` that broke development server

## Testing
- `npm run lint`
- `npm test`
- `npm run dev` and `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_68b9ecf144288325bf577fa1d8f2665d